### PR TITLE
Add support for detecting if running in a JUnit 5 test

### DIFF
--- a/src/main/java/org/logevents/LogEventFactory.java
+++ b/src/main/java/org/logevents/LogEventFactory.java
@@ -261,7 +261,7 @@ public class LogEventFactory implements ILoggerFactory {
      */
     protected boolean isRunningInsideJunit() {
         for (StackTraceElement stackTraceElement : new Throwable().getStackTrace()) {
-            if (stackTraceElement.getClassName().matches("^org.junit.(runners|platform.engine)")) {
+            if (stackTraceElement.getClassName().matches("^org.junit.(runners|platform.engine).*")) {
                 return true;
             }
         }

--- a/src/main/java/org/logevents/LogEventFactory.java
+++ b/src/main/java/org/logevents/LogEventFactory.java
@@ -261,7 +261,7 @@ public class LogEventFactory implements ILoggerFactory {
      */
     protected boolean isRunningInsideJunit() {
         for (StackTraceElement stackTraceElement : new Throwable().getStackTrace()) {
-            if (stackTraceElement.getClassName().startsWith("org.junit.runners")) {
+            if (stackTraceElement.getClassName().matches("^org.junit.(runners|platform.engine)")) {
                 return true;
             }
         }


### PR DESCRIPTION
Changed the class name condition for detecting if it is running inside a JUnit tests to a regex that will both match JUnit 4 and JUnit 5.