### PR TITLE
Can set ExpectedLogEventsRule to allow unexpectedLogEvents

### DIFF
--- a/logevents/src/test/java/org/logevents/extend/junit/ExpectedLogEventsRuleTest.java
+++ b/logevents/src/test/java/org/logevents/extend/junit/ExpectedLogEventsRuleTest.java
@@ -118,6 +118,35 @@ public class ExpectedLogEventsRuleTest {
     }
 
     @Test
+    public void shouldAllowUnexpectedEventsIfToldExcplicitly() {
+        logger.warn("This is a {} test for {}", "controversal", "the LogEvents author");
+        rule.setAllowUnexpectedLogs(true);
+
+        try {
+            rule.verifyCompletion();
+        } finally {
+            rule.setAllowUnexpectedLogs(false);
+        }
+    }
+
+    @Test
+    public void shouldSucceedWhenLoggingAsExpectedEvenIfThereAreUnexpectedEventsIfToldExcplicitly() {
+        rule.setAllowUnexpectedLogs(true);
+        rule.expectMatch(expect -> expect
+                .level(Level.WARN).logger(ExpectedLogEventsRuleTest.class)
+                .pattern("This is a {} test for {}").args("nice", "LogEvents"));
+
+        logger.warn("This is a {} test for {}", "nice", "LogEvents");
+        logger.warn("This is a {} test for {}", "unexpected", "LogEvents");
+
+        try {
+            rule.verifyCompletion();
+        } finally {
+            rule.setAllowUnexpectedLogs(false);
+        }
+    }
+
+    @Test
     public void shouldIgnoreUnmatchedEventsBelowThreshold() {
         logger.debug("This is a {} test for {}", "nice", "LogEvents");
         rule.verifyCompletion();


### PR DESCRIPTION
Easier to gradually introduce powerful test features like ExpectedLogEventsRule to your legacy test classes if you're able to allow unexpected events.

i.e if you want to add the a new test to an old class with many tests with noisy logs:
    
    @Rule
    public ExpectedLogEventsRule rule = new ExpectedLogEventsRule(Level.WARN, factory);

   @Before
    public void allowUnexpectedLogEventsByDefault(){
        rule.setAllowUnexpectedLogs(false);
    }

    @Test
    public void newTest() {
        rule.setAllowUnexpectedLogs(true);
        ....
   }