### PR TITLE
Junit5 support

### DIFF
--- a/logevents/pom.xml
+++ b/logevents/pom.xml
@@ -37,9 +37,15 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/logevents/src/main/java/org/logevents/extend/junit/ExpectedLogEventsExtension.java
+++ b/logevents/src/main/java/org/logevents/extend/junit/ExpectedLogEventsExtension.java
@@ -1,0 +1,215 @@
+package org.logevents.extend.junit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.logevents.LogEvent;
+import org.logevents.LogEventFactory;
+import org.logevents.LogEventObserver;
+import org.logevents.LoggerConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+/**
+ * A JUnit Extension class that can be used to verify that only expected messages are logged.
+ *
+ * <h2>Example</h2>
+ * <pre>
+ * public class ExampleTest {
+ *    private static final Logger logger = LoggerFactory.getLogger(ExampleTest.class)
+ *
+ *    &#064;RegisterExtension
+ *    public ExpectedLogEventsExtension expectLogEvents = new ExpectedLogEventsExtension(Level.WARN);
+ *
+ *    &#064;Test
+ *    public void willFailBecauseOfUnexpectedLogEvent() {
+ *        logger.warn("Whoa there!");
+ *    }
+ *
+ *    &#064;Test
+ *    public void willFailBecauseExpectedEventWasNotLogged() {
+ *        expectLogEvents.expect(ExampleTest.class, Level.WARN, "Whoa there!");
+ *    }
+ *
+ *    &#064;Test
+ *    public void willFailBecauseLogMessageDidNotMatch() {
+ *        expectLogEvents.expect(ExampleTest.class, Level.WARN, "Whoa there!");
+ *        logger.warn("Another message!");
+ *    }
+ *
+ *    &#064;Test
+ *    public void willPass() {
+ *        expectLogEvents.expect(ExampleTest.class, Level.WARN, "Whoa there!");
+ *        logger.warn("Whoa there!");
+ *    }
+ *
+ *    &#064;Test
+ *    public void willFailBecauseTheExceptionClassWasDifferent() {
+ *        // The expectations can be highly customized
+ *        expectLogEvents.expect(expect -&gt;
+ *          expect.level(Level.WARN).logger(ExampleTest.class).pattern("Whoa there!").exception(IOException.class)
+ *        );
+ *        logger.warn("Whoa there!", new RuntimeException("Uh oh"));
+ *    }
+ * }
+ * </pre>
+ */
+public class ExpectedLogEventsExtension implements
+                                        AfterEachCallback,
+                                        BeforeEachCallback,
+                                        LogEventObserver {
+
+    private LogEventFactory loggerFactory;
+    private Level threshold;
+    private List<LogEventMatcher> matchers = new ArrayList<>();
+    private List<LogEvent> events = new ArrayList<>();
+    private LogEventObserver fallbackObserver;
+    private boolean allowUnexpectedLogs = false;
+    private LoggerConfiguration logger;
+    private Level oldLevel;
+    private LogEventObserver oldObserver;
+
+    public ExpectedLogEventsExtension(Level threshold) {
+        this(threshold, (LogEventFactory)LoggerFactory.getILoggerFactory());
+    }
+
+    ExpectedLogEventsExtension(Level threshold, LogEventFactory loggerFactory) {
+        this.threshold = threshold;
+        this.loggerFactory = loggerFactory;
+    }
+
+    public void setAllowUnexpectedLogs(boolean allowUnexpectedLogs){
+        this.allowUnexpectedLogs = allowUnexpectedLogs;
+    }
+
+    @Override
+    public synchronized void logEvent(LogEvent logEvent) {
+        events.add(logEvent);
+        if (!logEvent.isBelowThreshold(threshold) && matchers.stream().noneMatch(f -> partialMatch(f, logEvent))) {
+            fallbackObserver.logEvent(logEvent);
+        }
+    }
+
+    public void expectMatch(LogEventMatcher matcher) {
+        this.matchers.add(matcher);
+    }
+
+    public void expectPattern(Class<?> logClass, Level level, String messagePattern) {
+        expectPattern(logClass.getName(), level, messagePattern);
+    }
+
+    public void expectPattern(String loggerName, Level level, String messagePattern) {
+        expectMatch(expect -> expect.level(level).logger(loggerName).pattern(messagePattern));
+    }
+
+    public void expect(Class<?> logClass, Level level, String formattedMessage) {
+        expect(logClass.getName(), level, formattedMessage);
+    }
+
+    public synchronized void expect(String loggerName, Level level, String formattedMessage) {
+        expectMatch(expect -> expect.level(level).logger(loggerName).formattedMessage(formattedMessage));
+    }
+
+    public void expect(Class<?> logClass, Level level, String formattedMessage, Throwable expectedException) {
+        expect(logClass.getName(), level, formattedMessage, expectedException);
+    }
+
+    public synchronized void expect(String loggerName, Level level, String formattedMessage, Throwable expectedException) {
+        expectMatch(expect -> expect.level(level).logger(loggerName).formattedMessage(formattedMessage)
+                        .exception(expectedException.getClass(), expectedException.getMessage())
+        );
+    }
+
+    public synchronized void verifyCompletion() {
+        try {
+            verifyAllExpectedLogsArePresent();
+
+            if(!allowUnexpectedLogs){
+                verifyNoUnexpectedLogsArePresent();
+            }
+        } finally {
+            matchers.clear();
+            events.clear();
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        try {
+            verifyCompletion();
+        } finally {
+            loggerFactory.setLevel(logger, oldLevel);
+            loggerFactory.setObserver(logger, oldObserver, true);
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        logger = loggerFactory.getRootLogger();
+        oldLevel = loggerFactory.setLevel(logger, Level.TRACE);
+        oldObserver = loggerFactory.setObserver(logger, ExpectedLogEventsExtension.this, false);
+        fallbackObserver = oldObserver;
+    }
+
+    private void verifyAllExpectedLogsArePresent() {
+        Optional<LogEventMatcher> firstMissedMatcher = matchers.stream()
+                .filter(m -> this.events.stream().noneMatch(e -> exactMatch(m, e)))
+                .findFirst();
+        firstMissedMatcher.ifPresent(matcher -> Assert.fail(failureMessage(matcher)));
+    }
+
+    private void verifyNoUnexpectedLogsArePresent() {
+        List<LogEvent> unexpectedEvents = new ArrayList<>(this.events);
+        unexpectedEvents.removeIf(event -> event.isBelowThreshold(threshold));
+        unexpectedEvents.removeIf(
+                event -> this.matchers.stream().anyMatch(filter -> exactMatch(filter, event))
+        );
+        if (!unexpectedEvents.isEmpty()) {
+            Assert.fail("Unexpected log message: " + unexpectedEvents.toString());
+        }
+    }
+
+    private boolean partialMatch(LogEventMatcher matcher, LogEvent event) {
+        return new LogEventMatcherContext(event, matcher).isPartialMatch();
+    }
+
+    private boolean exactMatch(LogEventMatcher matcher, LogEvent event) {
+        return new LogEventMatcherContext(event, matcher).isExactMatch();
+    }
+
+    private String failureMessage(LogEventMatcher matcher) {
+        List<LogEventMatcherContext> applicableMatches = events.stream()
+                .map(e -> new LogEventMatcherContext(e, matcher))
+                .filter(LogEventMatcherContext::isPartialMatch)
+                .collect(Collectors.toList());
+        if (applicableMatches.isEmpty()) {
+            applicableMatches = events.stream()
+                    .map(e -> new LogEventMatcherContext(e, matcher))
+                    .filter(m -> m.getMatchedFields().contains("logger"))
+                    .collect(Collectors.toList());
+        }
+        if (applicableMatches.isEmpty()) {
+            applicableMatches = events.stream()
+                    .filter(event -> !event.isBelowThreshold(threshold))
+                    .map(e -> new LogEventMatcherContext(e, matcher))
+                    .collect(Collectors.toList());
+        }
+        if (applicableMatches.isEmpty()) {
+            LogEvent dummyEvent = new LogEvent(null, null, null, null, new Object[0]);
+            return "Nothing logged. Expected " + new LogEventMatcherContext(dummyEvent, matcher).diff();
+        }
+
+        return "Expected message not logged: " + applicableMatches.get(0).describePartialMatch()
+                + ". Close matches: " + applicableMatches.stream().map(LogEventMatcherContext::diff).collect(Collectors.joining(", "));
+    }
+
+}

--- a/logevents/src/main/java/org/logevents/extend/junit/LogEventExtension.java
+++ b/logevents/src/main/java/org/logevents/extend/junit/LogEventExtension.java
@@ -1,0 +1,138 @@
+package org.logevents.extend.junit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.logevents.LogEvent;
+import org.logevents.LogEventFactory;
+import org.logevents.LogEventObserver;
+import org.logevents.formatting.MessageFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+public class LogEventExtension implements
+                               AfterEachCallback,
+                               BeforeEachCallback,
+                               LogEventObserver {
+
+    private final Logger logger;
+    private Level level;
+    private List<LogEvent> events = new ArrayList<>();
+    private LogEventFactory loggerFactory;
+    private Level oldLevel;
+    private LogEventObserver oldObserver;
+
+    public LogEventExtension(Level level, Logger logger) {
+        this.level = level;
+        this.logger = logger;
+    }
+
+    public LogEventExtension(Level level, String logName) {
+        this(level, LoggerFactory.getLogger(logName));
+    }
+
+    public LogEventExtension(Level level, Class<?> category) {
+        this(level, LoggerFactory.getLogger(category));
+    }
+
+    public void setLevel(Level level) {
+        this.level = level;
+        if (logger != null) {
+            LogEventFactory.getInstance().setLevel(logger, level);
+        }
+    }
+
+    public void assertNoMessages() {
+        assertTrue("Expected no log messages to " + logger + " was " + events,
+                events.isEmpty());
+    }
+
+    public void assertSingleMessage(Level level, String message) {
+        List<LogEvent> events = this.events.stream()
+            .filter(m -> m.getLevel().equals(level))
+            .collect(Collectors.toList());
+        assertTrue("Expected only one logged message at level " + level + ", but was " + events,
+                events.size() == 1);
+        assertEquals(message, formatMessage(events.get(0)));
+        assertEquals(level, events.get(0).getLevel());
+    }
+
+    public void assertContainsMessage(Level level, String message) {
+        assertFalse("Expected <" + message + "> but no messages were logged",
+                events.isEmpty());
+        for (LogEvent event : events) {
+            if (formatMessage(event).equals(message)) {
+                assertEquals("Log level for " + message, level, event.getLevel());
+                return;
+            }
+        }
+        fail("Could not find <" + message + "> in logged messages: " + events);
+    }
+
+    public String formatMessage(LogEvent event) {
+        return event.getMessage(new MessageFormatter());
+    }
+
+    public void assertContainsMessage(Level level, String message, Throwable throwable) {
+        assertFalse("Expected <" + message + "> but no messages were logged",
+                events.isEmpty());
+        List<String> messages = new ArrayList<>();
+        for (LogEvent event : events) {
+            String logMessage = formatMessage(event);
+            if (logMessage.equals(message)) {
+                assertEquals("Log level for " + message, level, event.getLevel());
+                assertExceptionEquals(message, throwable, event);
+                return;
+            }
+            messages.add(logMessage);
+        }
+        fail("Could not find <" + message + "> in logged messages: " + messages);
+    }
+
+
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        loggerFactory = (LogEventFactory) LoggerFactory.getILoggerFactory();
+
+        oldLevel = loggerFactory.setLevel(logger, level);
+        oldObserver = loggerFactory.setObserver(logger, LogEventExtension.this, false);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        loggerFactory.setLevel(logger, oldLevel);
+        loggerFactory.setObserver(logger, oldObserver, true);
+    }
+
+    void assertExceptionEquals(String message, Throwable throwable, LogEvent event) {
+        assertEquals("Exception for " + message, throwable.getClass(), event.getThrowable().getClass());
+        assertEquals("Exception for " + message, throwable.getMessage(), event.getThrowable().getMessage());
+    }
+
+    public void assertDoesNotContainMessage(String message) {
+        for (LogEvent event : events) {
+            if (formatMessage(event).equals(message)) {
+                fail("Did not expect to find find <" + message + "> in logged messages, but was " + event);
+            }
+        }
+    }
+
+    @Override
+    public void logEvent(LogEvent logEvent) {
+        this.events.add(logEvent);
+    }
+
+
+}

--- a/logevents/src/main/java/org/logevents/extend/junit/LogEventStatusExtension.java
+++ b/logevents/src/main/java/org/logevents/extend/junit/LogEventStatusExtension.java
@@ -1,0 +1,42 @@
+package org.logevents.extend.junit;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.logevents.status.LogEventStatus;
+import org.logevents.status.StatusEvent;
+import org.logevents.status.StatusEvent.StatusLevel;
+
+public class LogEventStatusExtension implements AfterEachCallback,
+                                                BeforeEachCallback {
+
+    private StatusEvent.StatusLevel level;
+    private StatusLevel oldThreshold;
+
+    public LogEventStatusExtension(StatusEvent.StatusLevel level) {
+        this.level = level;
+    }
+
+    public LogEventStatusExtension() {
+    }
+
+    public void setStatusLevel(StatusEvent.StatusLevel level) {
+        System.setProperty("logevents.status", level.name());
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        oldThreshold = LogEventStatus.getInstance().getThreshold(null);
+        if (level != null) {
+            LogEventStatus.getInstance().setThreshold(level);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        LogEventStatus.getInstance().setThreshold(oldThreshold);
+    }
+}

--- a/logevents/src/test/java/org/logevents/LogEventExtensionTest.java
+++ b/logevents/src/test/java/org/logevents/LogEventExtensionTest.java
@@ -1,0 +1,80 @@
+package org.logevents;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.logevents.extend.junit.LogEventExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+class LogEventExtensionTest {
+
+    private Logger logger = LoggerFactory.getLogger("com.example.application.Service");
+
+    @RegisterExtension
+    public LogEventExtension logEventExtension = new LogEventExtension(Level.DEBUG, "com.example");
+
+    @Test
+    public void shouldCaptureSingleLogEvent() {
+        logger.debug("Hello world");
+        logEventExtension.assertSingleMessage(Level.DEBUG, "Hello world");
+    }
+
+    @Test
+    public void shouldCaptureMultipleLogEvent() {
+        logger.debug("Not this one");
+        logger.debug("Hello world");
+        logger.info("Hello world");
+        logEventExtension.assertContainsMessage(Level.DEBUG, "Hello world");
+    }
+
+    @Test
+    public void shouldFailOnMissingLogEvent() {
+        logger.debug("Not this one");
+        try {
+            logEventExtension.assertContainsMessage(Level.DEBUG, "Hello world");
+            fail("Expected error");
+        } catch (AssertionError e) {
+            Assert.assertThat(e.getMessage(), CoreMatchers.containsString("Could not find <Hello world"));
+        }
+    }
+
+    @Test
+    public void shouldSuppressLogEvent() {
+        logger.error("Even though this is an error event, it is not displayed");
+    }
+
+    @Test
+    public void shouldNotCollectEventsBelowThreshold() {
+        logger.trace("Even though this is an error event, it is not displayed");
+        logEventExtension.assertNoMessages();
+        logEventExtension.assertDoesNotContainMessage("Even though this is an error event, it is not displayed");
+    }
+
+    @Test
+    public void shouldChangeCaptureLevel() {
+        logEventExtension.setLevel(Level.TRACE);
+        logger.trace("Trace message - SHOULD be logged");
+        logEventExtension.assertSingleMessage(Level.TRACE, "Trace message - SHOULD be logged");
+    }
+
+    @Test
+    public void shouldReportFailureOnAssertDoesNotContainMessage() {
+        logger.error("This error WAS expected");
+        logEventExtension.assertDoesNotContainMessage("This error was not expected");
+
+        logger.error("This error was not expected");
+        boolean threwException = true;
+        try {
+            logEventExtension.assertDoesNotContainMessage("This error was not expected");
+            threwException = false;
+        } catch (AssertionError e) {
+            assertTrue(e.toString(), e.toString().contains("Did not expect to find "));
+        }
+        assertTrue(threwException);
+    }
+}

--- a/logevents/src/test/java/org/logevents/extend/junit/ExpectedLogEventsExtensionTest.java
+++ b/logevents/src/test/java/org/logevents/extend/junit/ExpectedLogEventsExtensionTest.java
@@ -1,0 +1,154 @@
+package org.logevents.extend.junit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.io.IOException;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.logevents.LogEventFactory;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+public class ExpectedLogEventsExtensionTest {
+
+    private LogEventFactory factory = new LogEventFactory();
+
+    private Logger logger = factory.getLogger(getClass().getName());
+
+    @RegisterExtension
+    public ExpectedLogEventsExtension extension = new ExpectedLogEventsExtension(Level.WARN, factory);
+
+    @Test
+    public void shouldSucceedWhenLoggingAsExpected() {
+        extension.expectMatch(expect -> expect
+                .level(Level.WARN).logger(ExpectedLogEventsExtensionTest.class)
+                .pattern("This is a {} test for {}").args("nice", "LogEvents"));
+
+        logger.warn("This is a {} test for {}", "nice", "LogEvents");
+        extension.verifyCompletion();
+    }
+
+    @Test
+    public void shouldMatchExactly() {
+        extension.expect(ExpectedLogEventsExtensionTest.class, Level.WARN, "This is a nice test");
+        logger.warn("This is a {} test", "nice");
+        extension.verifyCompletion();
+    }
+
+    @Test
+    public void shouldFailWhenNoEventsAreLogged() {
+        extension.expectMatch(expect -> expect.level(Level.WARN).logger(getClass()).pattern("Test message"));
+        try {
+            extension.verifyCompletion();
+            fail("Expected exception");
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("Test message"));
+        }
+    }
+
+    @Test
+    public void shouldFailWhenNotMatchedExactly() {
+        extension.expect(ExpectedLogEventsExtensionTest.class, Level.WARN, "This is a bad test");
+        logger.warn("This is a {} test", "nice");
+        try {
+            extension.verifyCompletion();
+            fail("Expected exception");
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("This is a nice test"));
+        }
+    }
+
+    @Test
+    public void shouldMatchException() {
+        extension.expect(ExpectedLogEventsExtensionTest.class, Level.WARN, "This is a nice test",
+                new IOException("Uh oh!"));
+
+        logger.warn("This is a {} test", "nice", new IOException("Uh oh!"));
+        extension.verifyCompletion();
+    }
+
+    @Test
+    public void shouldFailWhenExceptionDoesntMatch() {
+        extension.expect(ExpectedLogEventsExtensionTest.class, Level.WARN, "This is a nice test",
+                new IOException("Uh oh!"));
+        logger.warn("This is a {} test", "nice", new IOException("Another message!"));
+        AssertionError caughtException = null;
+        try {
+            extension.verifyCompletion();
+        } catch (AssertionError e) {
+            caughtException = e;
+        }
+        assertNotNull(caughtException);
+        assertThat(caughtException.getMessage(), CoreMatchers.containsString("Another message!"));
+    }
+
+    @Test
+    public void shouldFailWhenWrongLoglevel() {
+        extension.expectPattern(ExpectedLogEventsExtensionTest.class, Level.WARN, "This is a {} test for {}");
+
+        logger.debug("This is a {} test for {}", "nice", "LogEvents");
+
+        AssertionError caughtException = null;
+        try {
+            extension.verifyCompletion();
+        } catch (AssertionError e) {
+            caughtException = e;
+        }
+        Assertions.assertNotNull(caughtException);
+        assertThat(caughtException.getMessage(), CoreMatchers.containsString(getClass().getName()));
+        assertThat(caughtException.getMessage(), CoreMatchers.containsString(""));
+    }
+
+    @Test
+    public void shouldFailWhenUnexpectedEvent() {
+        logger.warn("This is a {} test for {}", "nice", "LogEvents");
+
+        AssertionError caughtException = null;
+        try {
+            extension.verifyCompletion();
+        } catch (AssertionError e) {
+            caughtException = e;
+        }
+        Assertions.assertNotNull(caughtException);
+        assertThat(caughtException.getMessage(), CoreMatchers.containsString("Unexpected"));
+        assertThat(caughtException.getMessage(), CoreMatchers.containsString(getClass().getName()));
+    }
+
+    @Test
+    public void shouldAllowUnexpectedEventsIfToldExcplicitly() {
+        logger.warn("This is a {} test for {}", "controversal", "the LogEvents author");
+        extension.setAllowUnexpectedLogs(true);
+
+        try {
+            extension.verifyCompletion();
+        } finally {
+            extension.setAllowUnexpectedLogs(false);
+        }
+    }
+
+    @Test
+    public void shouldSucceedWhenLoggingAsExpectedEvenIfThereAreUnexpectedEventsIfToldExcplicitly() {
+        extension.setAllowUnexpectedLogs(true);
+        extension.expectMatch(expect -> expect
+                .level(Level.WARN).logger(ExpectedLogEventsExtensionTest.class)
+                .pattern("This is a {} test for {}").args("nice", "LogEvents"));
+
+        logger.warn("This is a {} test for {}", "nice", "LogEvents");
+        logger.warn("This is a {} test for {}", "unexpected", "LogEvents");
+
+        try {
+            extension.verifyCompletion();
+        } finally {
+            extension.setAllowUnexpectedLogs(false);
+        }
+    }
+
+    @Test
+    public void shouldIgnoreUnmatchedEventsBelowThreshold() {
+        logger.debug("This is a {} test for {}", "nice", "LogEvents");
+        extension.verifyCompletion();
+    }
+}

--- a/logevents/src/test/java/org/logevents/formatting/ExceptionFormatterTest.java
+++ b/logevents/src/test/java/org/logevents/formatting/ExceptionFormatterTest.java
@@ -224,8 +224,8 @@ public class ExceptionFormatterTest {
                 "\tat " + stackTrace[0] + " [rt.jar:" + javaVersion + "]",
                 "\tat " + stackTrace[1] + " [test-classes:na]",
                 "\tat " + stackTrace[2] + " [na:na]",
-                "\tat " + stackTrace[3] + " [junit-4.13.1.jar:4.13.1]",
-                "\tat " + stackTrace[4] + " [junit-4.13.1.jar:4.13.1]"),
+                "\tat " + stackTrace[3] + " [junit-4.13.2.jar:4.13.2]",
+                "\tat " + stackTrace[4] + " [junit-4.13.2.jar:4.13.2]"),
                 Arrays.asList(lines));
     }
 


### PR DESCRIPTION
Pull in junit5.x using the vintage engine to support the junit 4 engine
and associated tests.

Provide Extensions for Junit5 for which was available as Rules for
Junit4.